### PR TITLE
Feature/#5 블로그 리스트 페이지 관련 리팩토링

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import { fetchBlogList } from '@/features/blog/apis';
+import { BlogList } from '@/features/blog/components';
 
 export default async function Page({
   searchParams,
@@ -11,20 +11,7 @@ export default async function Page({
 
   return (
     <div>
-      {contents.map((data: any) => (
-        <div key={data.id} className='flex justify-between cursor-pointer'>
-          <div>
-            <p className='font-bold'>{data.title}</p>
-            <p>{data.content}</p>
-            <p className='font-light text-xs'>{data.date}</p>
-          </div>
-          <div className='relative w-16 h-16 bg-slate-100'>
-            <Image alt='blog-thumbnail' src={data.thumbnail} fill={true} />
-          </div>
-        </div>
-      ))}
-      <div>{searchParams.category}</div>
-      <div>{searchParams.tag}</div>
+      <BlogList contents={contents} />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import Image from 'next/image';
+import { BlogList } from '@/features/blog/components';
 import { fetchBlogList } from '@/features/blog/apis';
 
 export default async function Page() {
@@ -8,18 +8,7 @@ export default async function Page() {
     <>
       <article className='flex flex-col gap-5'>
         <p>전체글 ({`${contents.length}`})</p>
-        {contents.map((data: any) => (
-          <div key={data.id} className='flex justify-between cursor-pointer'>
-            <div>
-              <p className='font-bold'>{data.title}</p>
-              <p>{data.content}</p>
-              <p className='font-light text-xs'>{data.date}</p>
-            </div>
-            <div className='relative w-16 h-16 bg-slate-100'>
-              <Image alt='blog-thumbnail' src={data.thumbnail} fill={true} />
-            </div>
-          </div>
-        ))}
+        <BlogList contents={contents} />
       </article>
       <article
         style={{ columnGap: '3.875rem' }}

--- a/src/entities/blog/types/blog.ts
+++ b/src/entities/blog/types/blog.ts
@@ -1,0 +1,7 @@
+export type Blog = {
+  id: number;
+  title: string;
+  content: string;
+  date: string;
+  thumbnail: string;
+};

--- a/src/entities/blog/types/index.ts
+++ b/src/entities/blog/types/index.ts
@@ -1,0 +1,1 @@
+export type { Blog } from './blog';

--- a/src/features/blog/apis/fetchBlogList.ts
+++ b/src/features/blog/apis/fetchBlogList.ts
@@ -1,4 +1,12 @@
+import { Blog } from '@/entities/blog/types';
+
 // TODO: shared/apis에 공통 가공 처리 분리하기
+
+type FetchBlogListResponse = {
+  data: {
+    contents: Blog[];
+  };
+};
 
 export const fetchBlogList = async (params?: {
   category?: string;
@@ -17,6 +25,6 @@ export const fetchBlogList = async (params?: {
     `http://localhost:3000/api/blog${queryString ? `?${queryString}` : ''}`
   );
 
-  const { data } = await res.json();
-  return data;
+  const response: FetchBlogListResponse = await res.json();
+  return response.data;
 };

--- a/src/features/blog/components/BlogList.tsx
+++ b/src/features/blog/components/BlogList.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+
+import { Blog } from '@/entities/blog/types';
+
+export default function BlogList({ contents = [] }: { contents: Blog[] }) {
+  return (
+    <ul className='flex flex-col gap-5'>
+      {contents.map((data: any) => (
+        <li key={data.id} className='flex justify-between cursor-pointer'>
+          <div>
+            <p className='font-bold'>{data.title}</p>
+            <p>{data.content}</p>
+            <p className='font-light text-xs'>{data.date}</p>
+          </div>
+          <div className='relative w-16 h-16 bg-slate-100 border border-black'>
+            <Image
+              alt='blog-thumbnail'
+              src={data.thumbnail}
+              fill
+              sizes='100%, 100%'
+              style={{ objectFit: 'cover' }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/blog/components/index.ts
+++ b/src/features/blog/components/index.ts
@@ -1,0 +1,1 @@
+export { default as BlogList } from './BlogList';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/features/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
# 구현기능
- 블로그 리스트를 불러오는 뷰가 중복으로 사용되고 있어 컴포넌트화를 진행했습니다.
  - 메인 페이지에서 블로그 리스트를 불러옵니다.
  - 블로그 페이지에서 블로그 리스트를 불러옵니다.
 - src/features/components 로 분리한 컴포넌트에서 스타일이 적용되지 않는 문제가 있었습니다.
   -  tailwind.config.ts에 content에 경로를 추가했습니다.
   - content 속성에 정의된 경로들에 한해 tailwind가 CSS를 생성하는데, src/features/components 경로가 포함되지 않았기에 생기는 문제였습니다.
   - [참고 - tailwind CSS content-configuration](https://tailwindcss.com/docs/content-configuration)