### PR TITLE
Feature/#11 : 갤러리 목록 조회 페이지 구현

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,13 @@
+import { fetchGalleryList } from '@/features/gallery/apis';
+import { GalleryList } from '@/features/gallery/components';
+
+export default async function Page({
+  searchParams,
+}: Readonly<{
+  searchParams: { category?: string };
+}>) {
+  const { category } = searchParams;
+  const response = await fetchGalleryList({ category });
+
+  return <GalleryList contents={response.contents} />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,44 +1,20 @@
 import { BlogList } from '@/features/blog/components';
 import { fetchBlogList } from '@/features/blog/apis';
+import { GalleryList } from '@/features/gallery/components';
+import { fetchGalleryList } from '@/features/gallery/apis';
 
 export default async function Page() {
-  const { contents } = await fetchBlogList();
+  const { contents: blogContents } = await fetchBlogList();
+  const { contents: galleryContents } = await fetchGalleryList();
 
   return (
     <>
       <article className='flex flex-col gap-5'>
-        <p>전체글 ({`${contents.length}`})</p>
-        <BlogList contents={contents} />
+        <p>전체글 ({`${blogContents.length}`})</p>
+        <BlogList contents={blogContents} />
       </article>
-      <article
-        style={{ columnGap: '3.875rem' }}
-        className='flex flex-wrap gap-y-5 mt-10'
-      >
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
-
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
-        <div
-          style={{ width: '198px', height: '198px' }}
-          className='bg-slate-50'
-        />
+      <article className='mt-8'>
+        <GalleryList contents={galleryContents} />
       </article>
     </>
   );

--- a/src/entities/gallery/types/gallery.ts
+++ b/src/entities/gallery/types/gallery.ts
@@ -1,0 +1,7 @@
+export type Gallery = {
+  id: number;
+  slug: string;
+  title: string;
+  date: string;
+  thumbnail: string;
+};

--- a/src/entities/gallery/types/index.ts
+++ b/src/entities/gallery/types/index.ts
@@ -1,0 +1,1 @@
+export type { Gallery } from './gallery';

--- a/src/features/gallery/apis/fetchGalleryList.ts
+++ b/src/features/gallery/apis/fetchGalleryList.ts
@@ -1,0 +1,15 @@
+import { Gallery } from '@/entities/gallery/types';
+import { request } from '@/shared/apis';
+
+type FetchGalleryListResponse = {
+  contents: Gallery[];
+};
+
+export const fetchGalleryList = async (params?: { category: string }) => {
+  const searchParams = new URLSearchParams();
+
+  if (params?.category) searchParams.append('category', params.category);
+
+  const queryString = searchParams.toString();
+  return await request<FetchGalleryListResponse>(`/api/gallery?${queryString}`);
+};

--- a/src/features/gallery/apis/fetchGalleryList.ts
+++ b/src/features/gallery/apis/fetchGalleryList.ts
@@ -5,7 +5,7 @@ type FetchGalleryListResponse = {
   contents: Gallery[];
 };
 
-export const fetchGalleryList = async (params?: { category: string }) => {
+export const fetchGalleryList = async (params?: { category?: string }) => {
   const searchParams = new URLSearchParams();
 
   if (params?.category) searchParams.append('category', params.category);

--- a/src/features/gallery/apis/index.ts
+++ b/src/features/gallery/apis/index.ts
@@ -1,0 +1,1 @@
+export { fetchGalleryList } from './fetchGalleryList';

--- a/src/features/gallery/components/GalleryList.tsx
+++ b/src/features/gallery/components/GalleryList.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { Gallery } from '@/entities/gallery/types';
+import { ROUTES } from '@/shared/config/routes';
+
+export default function GalleryList({
+  contents,
+}: Readonly<{ contents: Gallery[] }>) {
+  return (
+    <div className='flex flex-wrap justify-between gap-x-14 gap-y-14'>
+      {contents.map((content) => (
+        <Link key={content.id} href={ROUTES.GALLERY.DETAIL(content.slug)}>
+          <div className='relative w-[198px] h-[198px] bg-slate-100 rounded overflow-hidden group '>
+            <Image
+              alt='gallery-post-thumbnail'
+              src={content.thumbnail}
+              height={198}
+              width={198}
+              className='object-cover'
+            />
+            <div className='absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300'>
+              <p className='font-medium text-white text-center p-2 pointer-events-none'>
+                {content.title}
+              </p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/features/gallery/components/index.ts
+++ b/src/features/gallery/components/index.ts
@@ -1,0 +1,1 @@
+export { default as GalleryList } from './GalleryList';

--- a/src/mocks/handlers/gallery.ts
+++ b/src/mocks/handlers/gallery.ts
@@ -1,0 +1,53 @@
+import { http, HttpResponse } from 'msw';
+import { MOCK_BASE_URL } from './constants';
+
+const getGalleryList = http.get(`${MOCK_BASE_URL}/api/gallery`, () => {
+  return HttpResponse.json({
+    data: {
+      contents: [
+        {
+          id: 1,
+          slug: 'first-gallery-content',
+          title: 'First Gallery Content',
+          date: '2024-07-21',
+          thumbnail:
+            'https://firebasestorage.googleapis.com/v0/b/my-blog-76a3f.appspot.com/o/76E90909-F619-4B11-90F8-873C51115085.JPG?alt=media&token=fc1e40c5-5397-497b-a33f-c974e294e7c4',
+        },
+        {
+          id: 2,
+          slug: 'second-gallery-content',
+          title: 'Second Gallery Content',
+          date: '2024-07-22',
+          thumbnail:
+            'https://firebasestorage.googleapis.com/v0/b/my-blog-76a3f.appspot.com/o/76E90909-F619-4B11-90F8-873C51115085.JPG?alt=media&token=fc1e40c5-5397-497b-a33f-c974e294e7c4',
+        },
+        {
+          id: 3,
+          slug: 'third-gallery-content',
+          title: 'Third Gallery Content',
+          date: '2024-07-23',
+          thumbnail:
+            'https://firebasestorage.googleapis.com/v0/b/my-blog-76a3f.appspot.com/o/76E90909-F619-4B11-90F8-873C51115085.JPG?alt=media&token=fc1e40c5-5397-497b-a33f-c974e294e7c4',
+        },
+        {
+          id: 4,
+          slug: 'fourth-gallery-content',
+          title: 'Fourth Gallery Content',
+          date: '2024-07-24',
+          thumbnail:
+            'https://firebasestorage.googleapis.com/v0/b/my-blog-76a3f.appspot.com/o/76E90909-F619-4B11-90F8-873C51115085.JPG?alt=media&token=fc1e40c5-5397-497b-a33f-c974e294e7c4',
+        },
+        {
+          id: 5,
+          slug: 'fifth-gallery-content',
+          title: 'Fifth Gallery Content',
+          date: '2024-07-25',
+          thumbnail:
+            'https://firebasestorage.googleapis.com/v0/b/my-blog-76a3f.appspot.com/o/76E90909-F619-4B11-90F8-873C51115085.JPG?alt=media&token=fc1e40c5-5397-497b-a33f-c974e294e7c4',
+        },
+      ],
+    },
+  });
+});
+
+export const galleryHandlers = [getGalleryList];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,4 @@
 import { blogHandlers } from './blog';
+import { galleryHandlers } from './gallery';
 
-export const handlers = [...blogHandlers];
+export const handlers = [...blogHandlers, ...galleryHandlers];

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -19,6 +19,7 @@ export const ROUTES = {
   GALLERY: {
     BASE: '/gallery',
     WITH_CATEGORY: (category: string) => `/gallery?category=${category}`,
+    DETAIL: (slug: string) => `/gallery/${slug}`,
   },
   PORTFOLIO: {
     BASE: '/portfolio',


### PR DESCRIPTION
# 구현 설명
- 갤러리 목록을 불러오는 api 모킹 `/api/gallery`
- 갤러리 목록을 불러오는 api 호출 함수 구현
- 갤러리 목록을 보여주는 GalleryList 컴포넌트화
  - 목록 아이템(글)을 클릭 시 상세 페이지로 이동
  - 목록 아이템(글) hover 시 글의 제목이 노출

- 갤러리 목록은 메인 페이지. 갤러리 목록 조회 페이지에서 사용됩니다.
- 갤러리 목록 조회 시는 category 별로 필터링이 이루어집니다.