### PR TITLE
Feature/#18 블로그 목록 조회, 블로그 글 상세 조회 API 구현

### DIFF
--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { collection, query, Query, where, getDocs } from 'firebase/firestore';
+import { fireStore as db } from '@/firebase/index';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { slug: string } }
+) {
+  let blogListQuery: Query = collection(db, 'blogs');
+
+  if (params.slug) {
+    blogListQuery = query(blogListQuery, where('slug', '==', params.slug));
+  }
+
+  const querySnapshot = await getDocs(blogListQuery);
+
+  if (querySnapshot.empty) {
+    return NextResponse.json(
+      { message: '존재하지 않는 블로그 제목입니다.' },
+      { status: 404 }
+    );
+  }
+
+  const doc = querySnapshot.docs[0];
+  const data = {
+    id: doc.id,
+    ...doc.data(),
+  };
+
+  return NextResponse.json({ message: 'success', data }, { status: 200 });
+}

--- a/src/app/api/blog/[slug]/route.ts
+++ b/src/app/api/blog/[slug]/route.ts
@@ -6,11 +6,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: { slug: string } }
 ) {
-  let blogListQuery: Query = collection(db, 'blogs');
-
-  if (params.slug) {
-    blogListQuery = query(blogListQuery, where('slug', '==', params.slug));
-  }
+  const blogListQuery = params.slug
+    ? query(collection(db, 'blogs'), where('slug', '==', params.slug))
+    : collection(db, 'blogs');
 
   const querySnapshot = await getDocs(blogListQuery);
 

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -7,28 +7,22 @@ import {
   query,
   where,
   Query,
-  WhereFilterOp,
+  QueryConstraint,
 } from 'firebase/firestore';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
 
-  const filters: { key: string; operation: WhereFilterOp }[] = [
-    {
-      key: 'category',
-      operation: '==',
-    },
-    { key: 'tags', operation: 'array-contains' },
-  ];
+  const category = searchParams.get('category');
+  const tags = searchParams.get('tags');
 
-  let blogListQuery: Query = collection(db, 'blogs');
+  const queries: QueryConstraint[] = [];
 
-  filters.forEach(({ key, operation }) => {
-    const value = searchParams.get(key);
-    if (value) {
-      blogListQuery = query(blogListQuery, where(key, operation, value));
-    }
-  });
+  if (category && category !== 'ALL')
+    queries.push(where('category', '==', category));
+  if (tags) queries.push(where('tags', 'array-contains', tags));
+
+  const blogListQuery: Query = query(collection(db, 'blogs'), ...queries);
 
   const querySnapshot = await getDocs(blogListQuery);
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,10 +4,10 @@ import { BlogList } from '@/features/blog/components';
 export default async function Page({
   searchParams,
 }: {
-  searchParams: { category?: string; tag?: string };
+  searchParams: { category?: string; tags?: string };
 }) {
-  const { tag, category } = searchParams;
-  const { contents } = await fetchBlogList({ tag, category });
+  const { tags, category } = searchParams;
+  const { contents } = await fetchBlogList({ tags, category });
 
   return (
     <div>

--- a/src/features/blog/apis/fetchBlogList.ts
+++ b/src/features/blog/apis/fetchBlogList.ts
@@ -7,13 +7,13 @@ type FetchBlogListResponse = {
 
 export const fetchBlogList = async (params?: {
   category?: string;
-  tag?: string;
+  tags?: string;
 }) => {
   const searchParams = new URLSearchParams();
 
   if (params) {
     if (params.category) searchParams.append('category', params.category);
-    if (params.tag) searchParams.append('tag', params.tag);
+    if (params.tags) searchParams.append('tags', params.tags);
   }
 
   const queryString = searchParams.toString();

--- a/src/firebase/firebaseConfig.ts
+++ b/src/firebase/firebaseConfig.ts
@@ -6,13 +6,13 @@ import { initializeApp } from 'firebase/app';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.FIREBASE_DATABASE_URL,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
 };
 
 const validateFirebaseConfig = (config: Record<string, string | undefined>) => {

--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -1,5 +1,8 @@
 import firebaseApp from './firebaseConfig';
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const fireStore = getFirestore(firebaseApp);
-export default fireStore;
+const storage = getStorage(firebaseApp);
+
+export { fireStore, storage };

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -13,7 +13,7 @@ export const ROUTES = {
   BLOG: {
     BASE: '/blog',
     WITH_CATEGORY: (category: string) => `/blog?category=${category}`,
-    WITH_TAG: (tag: string) => `/blog?tag=${tag}`,
+    WITH_TAG: (tag: string) => `/blog?tags=${tag}`,
     DETAIL: (slug: string) => `/blog/${slug}`,
   },
   GALLERY: {


### PR DESCRIPTION
- 파이어베이스 설정 시 필요한 .env에 있던 값들의 키를 변경했습니다.
  - 파이어베이스 파이어스토어와 스토리지는 클라이언트 사이드에서 사용할 일이 없어 NEXT_PUBLIC prefix를 제거했습니다.

- 블로그 목록 조회 API 구현
  - 카테고리, 태그로 필터링이 가능하도록 구현했습니다.
  - 기존 게시글과 tag는 1 : 1 관계로 구성했었는데 1 : N 관계로 변경했습니다. 
    -  데이터베이스 상에서 필드명을 tags로 변경하여 그에 맞추어 변수명을 변경했습니다. ([블로그 목록 조회 api query param 변경 commit](https://github.com/f-lab-edu/my-blog-space/commit/bde3423416f96588b7cc6070f437aa7d5c30f557#diff-da36b4f7c730f1a5aeb6f514e9acdc249763b4bd6bcf00210ac90c9a00366729))

- 블로그 글 상세 조회 API 구현
 