### PR TITLE
Feature/#31 관련 포스트 내비게이션

### DIFF
--- a/src/app/blog/[title]/layout.tsx
+++ b/src/app/blog/[title]/layout.tsx
@@ -1,8 +1,12 @@
 import './code.css';
 
+import Link from 'next/link';
+import dayjs from 'dayjs';
+
 import { queryBlogDetail } from '@/features/blog/apis';
 import { getTimeDifference } from '@/shared/lib/getTimeDifference';
 import Comment from '@/entities/comment/Utterances';
+import { ROUTES } from '@/shared/config/routes';
 
 export default async function BlogDetailLayout({
   children,
@@ -11,7 +15,8 @@ export default async function BlogDetailLayout({
   children: React.ReactNode;
   params: { title: string };
 }>) {
-  const { date, title, author } = await queryBlogDetail(params.title);
+  const { date, title, author, category, relatedBlogList } =
+    await queryBlogDetail(params.title);
 
   return (
     <article>
@@ -23,7 +28,32 @@ export default async function BlogDetailLayout({
         </div>
       </header>
       {children}
-      <div className='mt-8'>
+
+      <div className='mockup-browser border-base-300 border mt-20'>
+        <div className='mockup-browser-toolbar'>
+          <div className='input border-base-300 border'>
+            [{category}] 카테고리의 다른 글
+          </div>
+        </div>
+        <div className='border-base-300 flex justify-center border-t px-4 py-4'>
+          <ul className='w-full'>
+            {relatedBlogList.map((blog) => (
+              <li key={blog.id}>
+                <Link href={ROUTES.BLOG.DETAIL(blog.slug)}>
+                  <button className='btn btn-ghost btn-sm w-full text-left'>
+                    <p className='flex justify-between w-full'>
+                      <span>{blog.title}</span>
+                      <span>{dayjs(blog.createdAt).format('YYYY-MM-DD')}</span>
+                    </p>
+                  </button>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className='mt-20'>
         <Comment />
       </div>
     </article>

--- a/src/features/blog/apis/queryBlogDetail.ts
+++ b/src/features/blog/apis/queryBlogDetail.ts
@@ -1,4 +1,11 @@
-import { collection, query, where, getDocs } from 'firebase/firestore';
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  limit,
+  orderBy,
+} from 'firebase/firestore';
 import { fireStore as db, FIREBASE_COLLECTION_KEYS } from '@/firebase';
 import { CustomError } from '@/app/api/_lib/handler';
 
@@ -7,18 +14,50 @@ export const queryBlogDetail = async (slug: string) => {
 
   const blogListQuery = query(
     collection(db, FIREBASE_COLLECTION_KEYS.BLOGS),
-    where('slug', '==', slug)
+    where('slug', '==', slug),
+    limit(1)
   );
 
   const querySnapshot = await getDocs(blogListQuery);
   if (querySnapshot.empty) throw new CustomError(404);
 
   const doc = querySnapshot.docs[0];
+  const docData = doc.data();
+
+  const sameCategoryQuery = query(
+    collection(db, FIREBASE_COLLECTION_KEYS.BLOGS),
+    where('category', '==', docData.category),
+    orderBy('createdAt', 'desc')
+  );
+
+  const sameCategorySnapshot = await getDocs(sameCategoryQuery);
+  const sameCategoryList = sameCategorySnapshot.docs.map((doc) => {
+    const docData = doc.data();
+    return {
+      id: doc.id,
+      slug: docData.slug,
+      title: docData.title,
+      createdAt: docData.createdAt.toDate(),
+    };
+  });
+
+  const currentIndex = sameCategoryList.findIndex((blog) => blog.id === doc.id);
+
+  const prevList = sameCategoryList.slice(
+    Math.max(0, currentIndex - 3),
+    currentIndex
+  );
+  const nextList = sameCategoryList.slice(currentIndex + 1, currentIndex + 4);
+
+  const relatedBlogList = [...prevList, ...nextList];
+
   const data = {
     id: doc.id,
-    title: doc.data().title,
-    date: doc.data().date,
-    author: doc.data().author,
+    title: docData.title,
+    date: docData.date,
+    author: docData.author,
+    category: docData.category,
+    relatedBlogList,
   };
 
   return data;

--- a/src/features/blog/components/BlogList.tsx
+++ b/src/features/blog/components/BlogList.tsx
@@ -15,13 +15,14 @@ export default function BlogList({ contents = [] }: { contents: Blog[] }) {
               <p>{data.content}</p>
               <p className='font-light text-xs'>{data.date}</p>
             </div>
-            <div className='relative w-16 h-16 bg-slate-100 border border-black'>
+            <div className='relative w-16 h-16 bg-slate-100 overflow-clip'>
               <Image
-                alt='blog-thumbnail'
+                alt={`${data.title} thumbnail`}
                 src={data.thumbnail}
-                fill
-                sizes='100%, 100%'
+                width={64}
+                height={64}
                 style={{ objectFit: 'cover' }}
+                quality={60}
               />
             </div>
           </li>

--- a/src/features/gallery/components/GalleryList.tsx
+++ b/src/features/gallery/components/GalleryList.tsx
@@ -8,7 +8,7 @@ export default function GalleryList({
   contents,
 }: Readonly<{ contents: Gallery[] }>) {
   return (
-    <div className='flex flex-wrap justify-between gap-x-14 gap-y-14'>
+    <div className='flex flex-wrap gap-x-14 gap-y-14'>
       {contents.map((content) => (
         <Link key={content.id} href={ROUTES.GALLERY.DETAIL(content.slug)}>
           <div className='relative w-[198px] h-[198px] bg-slate-100 rounded overflow-hidden group '>


### PR DESCRIPTION
# 구현 기능
- 블로그 글의 하단에 현재 보고 있는 블로그 글과 같은 카테고리의 글 목록을 노출합니다.
- 목록에 있는 글들을 선택 시 해당 블로그 글로 이동합니다.
- 목록에 띄워지는 글의 기준은 아래와 같습니다.
  - 같은 카테고리의 글을 최신순으로 정렬했을 때, 현재 블로그 글과 전 후로 인접한 글 3개(최대 총 6개)를 노출합니다.