### PR TITLE
Feature/#31-1 createdAt 필드 추가 및 최신순 정렬 

### DIFF
--- a/src/app/api/guestbook/route.ts
+++ b/src/app/api/guestbook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { collection, addDoc } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 
 import { fireStore as db, FIREBASE_COLLECTION_KEYS } from '@/firebase';
 import { handler, CustomError } from '@/app/api/_lib/handler';
@@ -18,6 +18,7 @@ export const POST = handler(async (req: NextRequest) => {
       name,
       image: image ?? '',
       email: email ?? '',
+      createdAt: serverTimestamp(),
     }
   );
 

--- a/src/app/blog/[title]/layout.tsx
+++ b/src/app/blog/[title]/layout.tsx
@@ -15,7 +15,7 @@ export default async function BlogDetailLayout({
   children: React.ReactNode;
   params: { title: string };
 }>) {
-  const { date, title, author, category, relatedBlogList } =
+  const { createdAt, title, author, category, relatedBlogList } =
     await queryBlogDetail(params.title);
 
   return (
@@ -23,7 +23,7 @@ export default async function BlogDetailLayout({
       <header className='mb-8'>
         <h2 className='pb-2 text-center font-bold text-4xl'>{title}</h2>
         <div className='flex justify-center gap-2 font-light text-sm text-slate-600'>
-          <span>{getTimeDifference(date)}</span>
+          <span>{getTimeDifference(createdAt)}</span>
           <span>@{author}</span>
         </div>
       </header>

--- a/src/app/gallery/[title]/layout.tsx
+++ b/src/app/gallery/[title]/layout.tsx
@@ -9,14 +9,14 @@ export default async function BlogDetailLayout({
   children: React.ReactNode;
   params: { title: string };
 }>) {
-  const { date, title, artist } = await queryGalleryDetail(params.title);
+  const { createdAt, title, artist } = await queryGalleryDetail(params.title);
 
   return (
     <article>
       <header className='mb-8'>
         <h2 className='pb-2 text-center font-bold text-4xl'>{title}</h2>
         <div className='flex justify-center gap-2 font-light text-sm text-slate-600'>
-          <span>{getTimeDifference(date)}</span>
+          <span>{getTimeDifference(createdAt)}</span>
           <span>@{artist}</span>
         </div>
       </header>

--- a/src/app/guest/page.tsx
+++ b/src/app/guest/page.tsx
@@ -24,7 +24,7 @@ export default async function Page() {
               <div className='ml-4'>
                 <p className='font-bold'>{content.name}</p>
                 <p className='text-sm text-gray-500'>
-                  {dayjs(content.date).format('YYYY-MM-DD')}
+                  {dayjs(content.createdAt).format('YYYY-MM-DD')}
                 </p>
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  initMSW();
+  // initMSW();
 }
 
 function Header() {

--- a/src/entities/blog/types/blog.ts
+++ b/src/entities/blog/types/blog.ts
@@ -3,6 +3,6 @@ export type Blog = {
   slug: string;
   title: string;
   content: string;
-  date: string;
+  createdAt: Date;
   thumbnail: string;
 };

--- a/src/entities/gallery/types/gallery.ts
+++ b/src/entities/gallery/types/gallery.ts
@@ -2,6 +2,6 @@ export type Gallery = {
   id: string;
   slug: string;
   title: string;
-  date: string;
+  createdAt: Date;
   thumbnail: string;
 };

--- a/src/features/blog/apis/queryBlogDetail.ts
+++ b/src/features/blog/apis/queryBlogDetail.ts
@@ -54,7 +54,7 @@ export const queryBlogDetail = async (slug: string) => {
   const data = {
     id: doc.id,
     title: docData.title,
-    date: docData.date,
+    createdAt: docData.createdAt.toDate(),
     author: docData.author,
     category: docData.category,
     relatedBlogList,

--- a/src/features/blog/apis/queryBlogList.ts
+++ b/src/features/blog/apis/queryBlogList.ts
@@ -6,6 +6,7 @@ import {
   where,
   Query,
   QueryConstraint,
+  orderBy,
 } from 'firebase/firestore';
 import { CustomError } from '@/app/api/_lib/handler';
 
@@ -24,7 +25,8 @@ export const queryBlogList = async (params?: {
 
   const blogListQuery: Query = query(
     collection(db, FIREBASE_COLLECTION_KEYS.BLOGS),
-    ...queries
+    ...queries,
+    orderBy('createdAt', 'desc')
   );
 
   const querySnapshot = await getDocs(blogListQuery);
@@ -37,7 +39,7 @@ export const queryBlogList = async (params?: {
       slug: data.slug,
       title: data.title,
       content: data.content,
-      date: data.date,
+      createdAt: data.createdAt.toDate(),
       thumbnail: data.thumbnail,
     };
   });

--- a/src/features/blog/components/BlogList.tsx
+++ b/src/features/blog/components/BlogList.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
-
+import dayjs from 'dayjs';
 import { ROUTES } from '@/shared/config/routes';
 import { Blog } from '@/entities/blog/types';
 
@@ -13,7 +13,9 @@ export default function BlogList({ contents = [] }: { contents: Blog[] }) {
             <div>
               <p className='font-bold'>{data.title}</p>
               <p>{data.content}</p>
-              <p className='font-light text-xs'>{data.date}</p>
+              <p className='font-light text-xs'>
+                {dayjs(data.createdAt).format('YYYY-MM-DD')}
+              </p>
             </div>
             <div className='relative w-16 h-16 bg-slate-100 overflow-clip'>
               <Image

--- a/src/features/gallery/apis/queryGalleryDetail.ts
+++ b/src/features/gallery/apis/queryGalleryDetail.ts
@@ -19,7 +19,7 @@ export const queryGalleryDetail = async (slug: string) => {
   return {
     id: doc.id,
     artist: data.artist,
-    date: data.date,
+    createdAt: data.createdAt.toDate(),
     slug: data.slug,
     title: data.title,
   };

--- a/src/features/gallery/apis/queryGalleryList.ts
+++ b/src/features/gallery/apis/queryGalleryList.ts
@@ -1,5 +1,5 @@
 import { fireStore as db, FIREBASE_COLLECTION_KEYS } from '@/firebase';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
 
 import { CustomError } from '@/app/api/_lib/handler';
 
@@ -9,9 +9,13 @@ export const queryGalleryList = async (params?: { category?: string }) => {
   const galleryListQuery = category
     ? query(
         collection(db, FIREBASE_COLLECTION_KEYS.GALLERIES),
-        where('category', '==', category)
+        where('category', '==', category),
+        orderBy('createdAt', 'desc')
       )
-    : query(collection(db, FIREBASE_COLLECTION_KEYS.GALLERIES));
+    : query(
+        collection(db, FIREBASE_COLLECTION_KEYS.GALLERIES),
+        orderBy('createdAt', 'desc')
+      );
 
   const querySnapshot = await getDocs(galleryListQuery);
   if (querySnapshot.empty) throw new CustomError(400);
@@ -22,7 +26,7 @@ export const queryGalleryList = async (params?: { category?: string }) => {
       id: doc.id,
       slug: data.slug,
       title: data.title,
-      date: data.date,
+      createdAt: data.createdAt.toDate(),
       thumbnail: data.thumbnail,
     };
   });

--- a/src/features/guestbook/apis/postGuestbook.ts
+++ b/src/features/guestbook/apis/postGuestbook.ts
@@ -11,7 +11,6 @@ type PostGuestbookRequest = {
   name: string;
   image?: string;
   email?: string;
-  date: string;
 };
 
 export const postGuestbook = async (
@@ -21,7 +20,6 @@ export const postGuestbook = async (
     method: 'POST',
     body: {
       ...formData,
-      date: new Date().toISOString(),
     },
   });
 

--- a/src/features/guestbook/apis/queryGuestbookList.ts
+++ b/src/features/guestbook/apis/queryGuestbookList.ts
@@ -1,9 +1,12 @@
 import { fireStore as db, FIREBASE_COLLECTION_KEYS } from '@/firebase';
-import { collection, getDocs, query, where } from 'firebase/firestore';
+import { collection, getDocs, query, orderBy } from 'firebase/firestore';
 
 export const queryGuestbookList = async () => {
   const querySnapshot = await getDocs(
-    collection(db, FIREBASE_COLLECTION_KEYS.GUESTBOOK)
+    query(
+      collection(db, FIREBASE_COLLECTION_KEYS.GUESTBOOK),
+      orderBy('createdAt', 'desc')
+    )
   );
 
   const contents = querySnapshot.docs.map((doc) => {
@@ -15,7 +18,7 @@ export const queryGuestbookList = async () => {
       email: data.email,
       name: data.name,
       image: data.image,
-      date: data.date,
+      createdAt: data.createdAt.toDate(),
     };
   });
 


### PR DESCRIPTION
- https://github.com/f-lab-edu/my-blog-space/pull/32와 이어지는 PR입니다.
# 구현 기능
- 기존 YYYY-MM-DD 형식으로 존재하던 date 필드를 firestore의 timestamp로 바꾸었습니다.
- 클라이언트측에서 YYYY-MM-DD 포맷팅을 하도록 코드가 수정되었습니다.
- 목록을 조회하는 기능이 있을 시에는 createdAt을 기준으로 최신순으로 정렬하여 조회할 수 있도록 수정했습니다.